### PR TITLE
Solved fix bug

### DIFF
--- a/src/Avengers/Program.cs
+++ b/src/Avengers/Program.cs
@@ -56,7 +56,7 @@ public class AvengerBackendClient : IAvengerBackendClient
 
     public async Task<Decimal> GetPayment(Guid missionId)
     {
-        return await _daprClient.InvokeMethodAsync<Guid, Decimal>(HttpMethod.Get, "Payment", "payment", missionId);
+        return await _daprClient.InvokeMethodAsync<Guid, Decimal>(HttpMethod.Get, "Payment", "payment/" + missionId.ToString());
     }
 
     public async Task<List<Mission>> GetMissions()


### PR DESCRIPTION
The problem persisted in that when passing the GUID through the _daprClient.InvokeMethodAsync method it generates error in the validation, if instead of passing it as GUID we convert it as string the problem is solved.